### PR TITLE
Added the bug fix, mainly targeted at 64 bit systems.

### DIFF
--- a/include/bits.h
+++ b/include/bits.h
@@ -50,13 +50,13 @@ __BEGIN_CDECLS;
 
 static inline int bitmap_set(unsigned long *bitmap, int bit)
 {
-	unsigned long mask = 1 << BITMAP_BIT_IN_INT(bit);
+	unsigned long mask = 1UL << BITMAP_BIT_IN_INT(bit);
 	return atomic_or(&((int*)bitmap)[BITMAP_INT(bit)], mask) & mask ? 1 : 0;
 }
 
 static inline int bitmap_clear(unsigned long *bitmap, int bit)
 {
-	unsigned long mask = 1 << BITMAP_BIT_IN_INT(bit);
+	unsigned long mask = 1UL << BITMAP_BIT_IN_INT(bit);
 
 	return atomic_and(&((int*)bitmap)[BITMAP_INT(bit)], ~mask) & mask ? 1:0;
 }


### PR DESCRIPTION
Description: 1. In the given macro, 1 is considered as signed int by default. If it is left shifted by 31 then the result is a -ve number
is 2's complement representation. In such situation the value assigned to 1 would be undefined by standard. (C99).
If mask = 0x1f *bitmap:0x7fffffff Then expression(macros) evaluate to: mask = 1 << (0x1f & 01f);
mask = 0xffffffff80000000 and final answer should be *bitmap = 0xffffffff which comes out to be
*bitmap = 0xffffffffffffffff
